### PR TITLE
add rename method on FileBin prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,12 @@ fileBin.all().then(files => console.log(files));
 fileBin.write('CONTRIBUTORS.md', 'Pull requests accepted')
        .then(file => console.log(file));
 ```
+
+### Renaming a file
+
+`#rename` takes two arguments `oldFileName` and `newFileName`. It will rename the old file to the specified new file name and return the file object via a promise.
+
+```js
+fileBin.rename('old-name.md', 'new-name.md')
+       .then((file, oldFileName, newFileName) => console.log(`${oldFileName} was successfully renamed to ${newFileName}.`)
+```

--- a/index.js
+++ b/index.js
@@ -57,6 +57,19 @@ FileBin.prototype.write = function (fileName, data) {
   });
 };
 
+FileBin.prototype.rename = function (oldFileName, newFileName) {
+  var oldFullPath = path.join(this.base, oldFileName);
+  var newFullPath = path.join(this.base, newFileName);
+  return new RSVP.Promise((resolve, reject) => {
+    fs.rename(oldFullPath, newFullPath, (error) => {
+      if (error) { reject(error); }
+      this.find(newFileName).then((file) => {
+        return resolve(file, newFullPath, oldFullPath);
+      });
+    });
+  });
+};
+
 function filterInvalidExtensions(instance, files) {
   if (!instance.validExtensions.length) { return files; }
   return files.filter(file => {

--- a/test/file-bin-test.js
+++ b/test/file-bin-test.js
@@ -194,4 +194,33 @@ describe('fileBin - Instance', () => {
 
    });
 
+   describe('#rename', () => {
+      it('should have a #rename method', () => {
+        assert.isDefined(this.instance.rename);
+      });
+
+      it('should return a thenable', () => {
+        assert.isFunction(this.instance.rename('test.md', 'wowow.md').then);
+      });
+
+      it('should rename the file', (done) => {
+        this.instance.rename('first-file.md', 'wowowow.md').then(file => {
+          this.instance.list().then(fileNames => {
+            assert.include(fileNames, 'wowowow.md');
+            assert.notInclude(fileNames, 'first-file.md');
+            done();
+          });
+        }).catch(done);
+      });
+
+      it('returns the actual file', (done) => {
+        this.instance.rename('first-file.md', 'renamed-wowow.md').then(file => {
+          assert.equal(file.id, 'renamed-wowow.md');
+          assert.equal(file.content, 'first file content');
+          done();
+        }).catch(done);
+      });
+
+   });
+
 });


### PR DESCRIPTION
in regard to Issue #2 
we implemented the node [fs.rename()](https://nodejs.org/api/fs.html#fs_fs_rename_oldpath_newpath_callback) method to replace the old file name with the new file name. We wrote 3 tests in the same style as the tests for all other methods to ensure that our `.rename()` method works properly. @stevekinney please review - particularly [here](https://github.com/stevekinney/file-bin/compare/master...rossedfort:master#diff-2a02bbef7a1f961668b92817b9c63c22R209). Is there a way to refute the existence of the old file? This would make the test more _robust_
