### PR TITLE
add .getBaseDirectory() on FileBin prototype and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/README.md
+++ b/README.md
@@ -62,3 +62,12 @@ fileBin.all().then(files => console.log(files));
 fileBin.write('CONTRIBUTORS.md', 'Pull requests accepted')
        .then(file => console.log(file));
 ```
+
+### Renaming a file
+
+`#rename` takes two arguments `oldFileName` and `newFileName`. It will rename the old file to the specified new file name and return the file object via a promise.
+
+```js
+fileBin.rename('old-name.md', 'new-name.md')
+       .then((file, oldFileName, newFileName) => console.log(`${oldFileName} was successfully renamed to ${newFileName}.`)
+```

--- a/README.md
+++ b/README.md
@@ -71,3 +71,19 @@ fileBin.write('CONTRIBUTORS.md', 'Pull requests accepted')
 fileBin.rename('old-name.md', 'new-name.md')
        .then((file, oldFileName, newFileName) => console.log(`${oldFileName} was successfully renamed to ${newFileName}.`)
 ```
+
+### Base Directory Getters and Setters
+
+`#getBaseDirectory` can be called on a FileBin instance and it will return the current base directory.  
+
+`#setBaseDirectory('/new/base')` takes in a directory as an argument and will update the FileBin's base directory to the given directory.  
+
+```js
+var fileBin = new FileBin('/some/directory')
+
+console.log(fileBin.getBaseDirectory()); // --> /some/directory;
+
+fileBin.setBaseDirectory('/new/base');
+
+console.log(fileBin.getBaseDirectory()); // --> /new/base;
+```

--- a/index.js
+++ b/index.js
@@ -57,6 +57,19 @@ FileBin.prototype.write = function (fileName, data) {
   });
 };
 
+FileBin.prototype.rename = function (oldFileName, newFileName) {
+  var oldFullPath = path.join(this.base, oldFileName);
+  var newFullPath = path.join(this.base, newFileName);
+  return new RSVP.Promise((resolve, reject) => {
+    fs.rename(oldFullPath, newFullPath, (error) => {
+      if (error) { reject(error); }
+      this.find(newFileName).then((file) => {
+        return resolve(file, newFullPath, oldFullPath);
+      });
+    });
+  });
+};
+
 function filterInvalidExtensions(instance, files) {
   if (!instance.validExtensions.length) { return files; }
   return files.filter(file => {

--- a/index.js
+++ b/index.js
@@ -57,6 +57,10 @@ FileBin.prototype.write = function (fileName, data) {
   });
 };
 
+FileBin.prototype.getBaseDirectory = function() {
+  return this.base;
+};
+
 function filterInvalidExtensions(instance, files) {
   if (!instance.validExtensions.length) { return files; }
   return files.filter(file => {

--- a/test/file-bin-test.js
+++ b/test/file-bin-test.js
@@ -194,4 +194,33 @@ describe('fileBin - Instance', () => {
 
    });
 
+   describe('#rename', () => {
+      it('should have a #rename method', () => {
+        assert.isDefined(this.instance.rename);
+      });
+
+      it('should return a thenable', () => {
+        assert.isFunction(this.instance.rename('test.md', 'wowow.md').then);
+      });
+
+      it('should rename the file', (done) => {
+        this.instance.rename('first-file.md', 'wowowow.md').then(file => {
+          this.instance.list().then(fileNames => {
+            assert.include(fileNames, 'wowowow.md');
+            assert.notInclude(fileNames, 'first-file.md');
+            done();
+          });
+        }).catch(done);
+      });
+
+      it('returns the actual file', (done) => {
+        this.instance.rename('first-file.md', 'renamed-wowow.md').then(file => {
+          assert.equal(file.id, 'renamed-wowow.md');
+          assert.equal(file.content, 'first file content');
+          done();
+        }).catch(done);
+      });
+
+   });
+
 });

--- a/test/file-bin-test.js
+++ b/test/file-bin-test.js
@@ -194,4 +194,15 @@ describe('fileBin - Instance', () => {
 
    });
 
+   describe('#getBaseDirectory', () => {
+
+     it('should have a #getBaseDirectory method', () => {
+       assert.isDefined(this.instance.getBaseDirectory);
+     });
+
+     it('should return the base directory', () => {
+       assert.equal('/some/directory', this.instance.getBaseDirectory())
+     });
+   });
+
 });


### PR DESCRIPTION
Implemented .getBaseDirectory(). Pretty straightforward. As of right now, I can't think of any sad paths to test. I'll go back and refactor other files to use .getBaseDirectory() instead of this.base once this is merged.
