### PR TITLE
Updated readme to reflect the current version of destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ fileBin.rename('old-name.md', 'new-name.md')
 
 ### Destroying a file
 
-`#destroy` takes a single argument of the `fileName` that you want to delete. It will delete the specified file and return true via a promise.
+`#destroy` takes a single argument of the `fileName` that you want to delete. It will delete the specified file and return the `fileName` via a promise.
 
 ```js
 fileBin.destroy('filename.md')
-  .then(console.log(`true`))
+  .then(console.log(`filename.md`))
 ```
 
 ### Copying a File


### PR DESCRIPTION
I changed the documentation for `destroy()` to reflect the updated version. 

The method was changed to resolve the fileName instead of true.
